### PR TITLE
Changes to match cyclic-router PR for Sink type

### DIFF
--- a/template/src/interfaces.ts
+++ b/template/src/interfaces.ts
@@ -2,7 +2,7 @@ import { Stream } from 'xstream';
 import { DOMSource, VNode } from '@cycle/dom';
 import { HTTPSource, RequestOptions } from '@cycle/http';
 import { TimeSource } from '@cycle/time';
-import { RouterSource } from 'cyclic-router';
+import { RouterSource, HistoryAction } from 'cyclic-router';
 
 export type Component = (s: BaseSources) => BaseSinks;
 
@@ -17,7 +17,7 @@ export interface BaseSources {
 export interface BaseSinks {
     DOM?: Stream<VNode>;
     HTTP?: Stream<RequestOptions>;
-    router?: Stream<string | object>;
+    router?: Stream<HistoryAction>;
     storage?: Stream<any>;
     speech?: Stream<string>;
 }

--- a/template/src/routes.ts
+++ b/template/src/routes.ts
@@ -1,5 +1,4 @@
 import { Component } from './interfaces';
-
 import { Counter } from './components/counter';
 import { Speaker } from './components/speaker';
 


### PR DESCRIPTION
Looks like `custom-typings` already cleaned out