### PR TITLE
Cross platform path resoultion in scripts

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -8,7 +8,7 @@ env.NODE_ENV = 'production';
 const webpackAPI = require.resolve('webpack');
 
 const webpack = path.resolve(
-    webpackAPI.slice(0, webpackAPI.lastIndexOf('/')),
+    path.dirname(webpackAPI),
     '..',
     'bin',
     'webpack.js'

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -8,7 +8,7 @@ env.NODE_ENV = 'development';
 const webpackAPI = require.resolve('webpack-dev-server');
 
 const webpack = path.resolve(
-    webpackAPI.slice(0, webpackAPI.lastIndexOf('/')),
+    path.dirname(webpackAPI),
     '..',
     'bin',
     'webpack-dev-server.js'

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -9,7 +9,7 @@ env.NODE_ENV = 'test';
 
 const nycAPI = require.resolve('nyc');
 const nyc = path.resolve(
-    nycAPI.slice(0, nycAPI.lastIndexOf('/')),
+    path.dirname(nycAPI),    
     'bin',
     'nyc.js'
 );


### PR DESCRIPTION
Found three issues in scripts where the path resolution is not cross-platform compatible. The default path delimiter on windows is backslash (`\`). 

Please don't mind the separate commits; I had to edit directly on GitHub, as I'm on vacation in the canaries, and my LTE connection is somewhat flaky.