### PR TITLE
Update sass options to new config object

### DIFF
--- a/configs/webpack.config.js
+++ b/configs/webpack.config.js
@@ -53,7 +53,9 @@ module.exports = webpackMerge(
             [
                 css(),
                 sass({
-                    includePaths: [appPath('node_modules')],
+                    sassOptions: {
+                        includePaths: [appPath('node_modules')],
+                    },
                     sourceMap: true
                 }),
                 postcss({


### PR DESCRIPTION
Webpacks `sass-loader` migrated to a new version of the config object a long time ago. This now requires the includePaths to be set in the sassOptions map. When creating a new cycle project via `create-cycle-app`, the config error is the first thing that pops up when starting the project.

More information can be found here:
* https://github.com/webpack-contrib/sass-loader/issues/756#issuecomment-528310376
* https://webpack.js.org/loaders/sass-loader/#sassoptions